### PR TITLE
Enhance Protfolio component with new tasks and reload functionality

### DIFF
--- a/sdl-frontend-main/src/pages/protfolio/Protfolio.jsx
+++ b/sdl-frontend-main/src/pages/protfolio/Protfolio.jsx
@@ -104,9 +104,14 @@ export default function Protfolio() {
         "3-3": "撰寫研究結果",
         "4-1": "檢視研究進度",
         "4-2": "進行研究討論",
-        "4-3": "撰寫研究結論"
+        "4-3": "撰寫研究結論",
+        "5-1": "封面製作",
+        "5-2": "摘要撰寫",
+        "5-3": "目錄編制",
+        "5-4": "內容撰寫",
+        "5-5": "反思撰寫"
     };
-    const insertTitles = ["定標", "擇策", "監評", "調節"];
+    const insertTitles = ["定標", "擇策", "監評", "調節", "歷程"];
 
     useEffect(() => {
         if (stagePortfolio.length > 0) {
@@ -144,10 +149,17 @@ export default function Protfolio() {
     formData.append('attachFile', file);  // 欄位名稱要跟後端 upload.array 的 key 一致
     try {
       await updateSubmitAttachment(modalData.id, formData);
-      Swal.fire({ icon: 'success', title: '檔案重新上傳成功', confirmButtonColor: '#5BA491' });
-      // 更新列表
-      queryClient.invalidateQueries('protfolioDatas');
-      setFolderModalOpen(false);
+      Swal.fire({ 
+        icon: 'success', 
+        title: '檔案重新上傳成功', 
+        confirmButtonColor: '#5BA491' 
+      }).then(() => {
+        // 更新列表
+        queryClient.invalidateQueries('protfolioDatas');
+        setFolderModalOpen(false);
+        // 刷新頁面
+        window.location.reload();
+      });
     } catch (err) {
       console.error(err);
       Swal.fire({ icon: 'error', title: '重新上傳失敗', text: '請稍後再試', confirmButtonColor: '#d33' });


### PR DESCRIPTION
- Added new tasks: "封面製作", "摘要撰寫", "目錄編制", "內容撰寫", and "反思撰寫" to the task list.
- Updated `insertTitles` to include "歷程".
- Modified success alert to reload the page after file upload, ensuring the latest data is displayed.